### PR TITLE
Add LaunchDarkly event schema header to all requests to LaunchDarkly

### DIFF
--- a/packages/destination-actions/src/destinations/launchdarkly/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly/index.ts
@@ -44,7 +44,11 @@ const destination: DestinationDefinition<Settings> = {
 
   extendRequest: () => {
     return {
-      headers: { 'User-Agent': 'SegmentDestination/2.0.0', 'Content-Type': 'application/json' }
+      headers: {
+        'User-Agent': 'SegmentDestination/2.0.0',
+        'Content-Type': 'application/json',
+        'X-LaunchDarkly-Event-Schema': '3'
+      }
     }
   },
   presets,

--- a/packages/destination-actions/src/destinations/launchdarkly/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly/index.ts
@@ -45,7 +45,7 @@ const destination: DestinationDefinition<Settings> = {
   extendRequest: () => {
     return {
       headers: {
-        'User-Agent': 'SegmentDestination/2.0.0',
+        'User-Agent': 'SegmentDestination/2.0.1',
         'Content-Type': 'application/json',
         'X-LaunchDarkly-Event-Schema': '3'
       }


### PR DESCRIPTION
This PR updates the headers added by the `extendRequest` function to also include the `X-LaunchDarkly-Event-Schema` version header.
